### PR TITLE
Update README to add subcommand 'install'

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 racket-cheat - a cheat sheet for Racket
 
 INSTALL:
-$ raco pkg racket-cheat
+$ raco pkg install racket-cheat
 
 Look at the top of your docs
 


### PR DESCRIPTION
DrRacket 6.2.1 needs the pkg subcommand 'install' added, not sure if this affects earlier versions.
